### PR TITLE
Fixing problem with multiple watchdogs being started

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,4 +5,4 @@ options:
       Prometheus Configurer has been designed to support multiple tenants. This label can be used
       to restrict the alerting rules in Prometheus, so that each rule can only be triggered by 
       metrics with matching label.
-    default: networkID
+    default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -5,5 +5,5 @@ options:
       Prometheus Configurer has been designed to support multiple tenants. This label can be used
       to restrict the alerting rules in Prometheus, so that each rule can only be triggered by 
       metrics with matching label. If none is set, Prometheus Configurer's default value 
-      od 'tenant' will be used.
+      of 'tenant' will be used.
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -4,5 +4,6 @@ options:
     description: |
       Prometheus Configurer has been designed to support multiple tenants. This label can be used
       to restrict the alerting rules in Prometheus, so that each rule can only be triggered by 
-      metrics with matching label.
+      metrics with matching label. If none is set, Prometheus Configurer's default value 
+      od 'tenant' will be used.
     default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,7 @@ class PrometheusConfigurerOperatorCharm(CharmBase):
             ],
         )
 
+        self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(
             self.on.prometheus_configurer_pebble_ready,
             self._on_prometheus_configurer_pebble_ready,
@@ -72,6 +73,11 @@ class PrometheusConfigurerOperatorCharm(CharmBase):
             self.on.prometheus_configurer_relation_joined,
             self._on_prometheus_configurer_relation_joined,
         )
+
+    def _on_start(self, _) -> None:
+        """Starts AlertRulesDirWatcher upon unit start."""
+        watchdog = AlertRulesDirWatcher(self, self.RULES_DIR)
+        watchdog.start_watchdog()
 
     def _on_prometheus_configurer_pebble_ready(self, event: PebbleReadyEvent):
         """Checks whether all conditions to start Prometheus Configurer are met and, if yes,

--- a/src/charm.py
+++ b/src/charm.py
@@ -189,13 +189,7 @@ class PrometheusConfigurerOperatorCharm(CharmBase):
                     self._prometheus_configurer_service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": "prometheus_configurer "
-                        f"-port={str(self.PROMETHEUS_CONFIGURER_PORT)} "
-                        f"-rules-dir={self.RULES_DIR}/ "
-                        "-prometheusURL="
-                        f"{self.DUMMY_HTTP_SERVER_HOST}:{self.DUMMY_HTTP_SERVER_PORT} "
-                        f'-multitenant-label={self.model.config.get("multitenant_label")} '
-                        "-restrict-queries",
+                        "command": self._prometheus_configurer_service_startup_command,
                     }
                 },
             }
@@ -221,6 +215,20 @@ class PrometheusConfigurerOperatorCharm(CharmBase):
                 },
             }
         )
+
+    @property
+    def _prometheus_configurer_service_startup_command(self) -> str:
+        command = (
+            "prometheus_configurer "
+            f"-port={str(self.PROMETHEUS_CONFIGURER_PORT)} "
+            f"-rules-dir={self.RULES_DIR}/ "
+            f"-prometheusURL={self.DUMMY_HTTP_SERVER_HOST}:{self.DUMMY_HTTP_SERVER_PORT} "
+            "-restrict-queries"
+        )
+        multitenant_label = self.model.config.get("multitenant_label")
+        if multitenant_label:
+            command = command + f" -multitenant-label={multitenant_label}"
+        return command
 
     @property
     def _dummy_http_server_running(self) -> bool:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -111,12 +111,12 @@ class TestPrometheusConfigurerOperatorCharm:
                 "juju_charm": f"{PROMETHEUS_CONFIGURER_APP_NAME}",
                 "juju_model": f"{model_name}",
                 "juju_model_uuid": f"{model_uuid}",
-                "networkID": f"{TEST_TENANT}",
                 "severity": "Low",
+                "tenant": f"{TEST_TENANT}",
             },
             "lastEvaluation": "0001-01-01T00:00:00Z",
             "name": f"{TEST_ALERT_NAME}",
-            "query": f'process_cpu_seconds_total{{juju_application="{PROMETHEUS_CONFIGURER_APP_NAME}",juju_charm="{PROMETHEUS_CONFIGURER_APP_NAME}",juju_model="{model_name}",juju_model_uuid="{model_uuid}",networkID="{TEST_TENANT}"}} '  # noqa: E501
+            "query": f'process_cpu_seconds_total{{juju_application="{PROMETHEUS_CONFIGURER_APP_NAME}",juju_charm="{PROMETHEUS_CONFIGURER_APP_NAME}",juju_model="{model_name}",juju_model_uuid="{model_uuid}",tenant="{TEST_TENANT}"}} '  # noqa: E501
             "> 0.12",
             "state": "inactive",
             "type": "alerting",
@@ -144,9 +144,9 @@ class TestPrometheusConfigurerOperatorCharm:
         )
         expected_response = {
             "alert": f"{TEST_ALERT_NAME}",
-            "expr": f'process_cpu_seconds_total{{networkID="{TEST_TENANT}"}} > 0.12',
+            "expr": f'process_cpu_seconds_total{{tenant="{TEST_TENANT}"}} > 0.12',
             "for": "0s",
-            "labels": {"networkID": f"{TEST_TENANT}", "severity": "Low"},
+            "labels": {"tenant": f"{TEST_TENANT}", "severity": "Low"},
             "annotations": {"description": "Rule description.", "summary": "Rule summary."},
         }
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -123,8 +123,8 @@ class TestPrometheusConfigurerOperatorCharm(unittest.TestCase):
                     f"-port={test_prometheus_configurer_port} "
                     f"-rules-dir={test_rules_dir}/ "
                     f"-prometheusURL={test_dummy_http_server_host}:{test_dummy_http_server_port} "
-                    f"-multitenant-label={TEST_MULTITENANT_LABEL} "
-                    "-restrict-queries",
+                    "-restrict-queries "
+                    f"-multitenant-label={TEST_MULTITENANT_LABEL}",
                 }
             }
         }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -43,7 +43,8 @@ class TestPrometheusConfigurerOperatorCharm(unittest.TestCase):
     ):
         test_rules_dir = "/test/rules/dir"
         patched_rules_dir.return_value = test_rules_dir
-        self.harness.container_pebble_ready("prometheus-configurer")
+
+        self.harness.charm.on.start.emit()
 
         patched_alert_rules_dir_watcher.assert_called_with(self.harness.charm, test_rules_dir)
 


### PR DESCRIPTION
# Description

Fixes problem with multiple watchdog instances being started in case the `pebble-ready` event is defered.
Removes default value of the `multitenant_label` parameter, since it's Magma specific.
Updates prometheus_remote_write lib to the latest version.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
