### PR TITLE
Fixes CI and unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,10 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+
       - name: Run integration tests
         run: tox -e integration
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   static-analysis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ module = ["ops.*", "lightkube.*", "git.*", "pytest_operator.*", "validators.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["charms.grafana_k8s.*", "charms.observability_libs.*"]
+module = ["charms.grafana_k8s.*", "charms.observability_libs.*", "charms.prometheus_k8s.*"]
 follow_imports = "silent"
 warn_unused_ignores = false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
-ops==2.0.0rc2
+ops
 PyYAML
 watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
-ops
+ops <= 1.5.4
 PyYAML
 watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
-ops==1.5.2
+ops==2.0.0rc2
 PyYAML
 watchdog

--- a/src/rules_dir_watcher.py
+++ b/src/rules_dir_watcher.py
@@ -17,8 +17,8 @@ import time
 
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, Object
-from watchdog.events import FileSystemEventHandler  # type: ignore[import]
-from watchdog.observers import Observer  # type: ignore[import]
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -65,7 +65,7 @@ class TestPrometheusConfigurerOperatorCharm:
             relation2="prometheus-k8s:receive-remote-write",
         )
         await ops_test.model.wait_for_idle(
-            apps=[PROMETHEUS_CONFIGURER_APP_NAME],
+            apps=[PROMETHEUS_CONFIGURER_APP_NAME, PROMETHEUS_APP_NAME],
             status="active",
             timeout=WAIT_FOR_STATUS_TIMEOUT,
         )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -194,7 +194,7 @@ class TestPrometheusConfigurerOperatorCharm:
         await ops_test.model.deploy(
             PROMETHEUS_APP_NAME,
             application_name=PROMETHEUS_APP_NAME,
-            channel="edge",
+            channel="stable",
             trust=True,
             series="focal",
         )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -39,7 +39,11 @@ class TestPrometheusConfigurerOperatorCharm:
             ],
         }
         await ops_test.model.deploy(
-            charm, resources=resources, application_name=PROMETHEUS_CONFIGURER_APP_NAME, trust=True
+            charm,
+            resources=resources,
+            application_name=PROMETHEUS_CONFIGURER_APP_NAME,
+            trust=True,
+            series="focal",
         )
 
     @pytest.mark.abort_on_fail
@@ -192,6 +196,7 @@ class TestPrometheusConfigurerOperatorCharm:
             application_name=PROMETHEUS_APP_NAME,
             channel="edge",
             trust=True,
+            series="focal",
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ commands =
 description = Run integration tests
 deps =
     aiohttp
-    juju
+    juju==3.0.4
     pytest
     pytest-operator
     pytest-httpserver

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ commands =
 description = Run integration tests
 deps =
     aiohttp
-    juju==3.0.4
+    juju
     pytest
     pytest-operator
     pytest-httpserver


### PR DESCRIPTION
# Description

Fixes CI pipeline issues:
- Excludes Prometheus library from static analysis.
- Adds `series="focal"` in the integration tests.
- Sets `prometheus-k8s` to be deployed from `stable` instead of `edge`.
- With the recent release of [ops `2.0.0`](https://pypi.org/project/ops/#history) some unit tests break, we fix `ops` to `1.5.4` temporarily before we refactor unit tests for supporting `ops=>2`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
