### PR TITLE
Validates that prometheus is active before checking for rules

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -39,7 +39,11 @@ class TestPrometheusConfigurerOperatorCharm:
             ],
         }
         await ops_test.model.deploy(
-            charm, resources=resources, application_name=PROMETHEUS_CONFIGURER_APP_NAME, trust=True
+            charm,
+            resources=resources,
+            application_name=PROMETHEUS_CONFIGURER_APP_NAME,
+            trust=True,
+            series="focal",
         )
 
     @pytest.mark.abort_on_fail
@@ -190,8 +194,9 @@ class TestPrometheusConfigurerOperatorCharm:
         await ops_test.model.deploy(
             PROMETHEUS_APP_NAME,
             application_name=PROMETHEUS_APP_NAME,
-            channel="edge",
+            channel="stable",
             trust=True,
+            series="focal",
         )
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -61,7 +61,7 @@ class TestPrometheusConfigurerOperatorCharm:
             relation2="prometheus-k8s:receive-remote-write",
         )
         await ops_test.model.wait_for_idle(
-            apps=[PROMETHEUS_CONFIGURER_APP_NAME],
+            apps=[PROMETHEUS_CONFIGURER_APP_NAME, PROMETHEUS_APP_NAME],
             status="active",
             timeout=WAIT_FOR_STATUS_TIMEOUT,
         )


### PR DESCRIPTION
# Description

Validates that prometheus is active before checking for rules

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
